### PR TITLE
Fix pandoraPatRecInit config.

### DIFF
--- a/fcl/reco/MCC10/reco_uboone_data_mcc9_10.fcl
+++ b/fcl/reco/MCC10/reco_uboone_data_mcc9_10.fcl
@@ -674,7 +674,7 @@ microboone_reco_data_producers.trajclusterKalmanTrack.seedFromPF:               
 
 # Pandora consolidated reconstruction (pre-NuGraph2)
 microboone_reco_data_producers.pandoraPatRecInit.HitFinderModuleLabel:                                        "gaushit"
-microboone_reco_data_producers.pandoraPatRecInit.ConfigFile:                                                  "PandoraSettings_Master_MicroBooNE_DL.xml"
+microboone_reco_data_producers.pandoraPatRecInit.ConfigFile:                                                  "PandoraSettings_Master_MicroBooNE.xml"
 microboone_reco_data_producers.pandoraAllOutcomesTrackInit.PFParticleLabel:                                   "pandoraPatRecInit:allOutcomes"
 microboone_reco_data_producers.pandoraAllOutcomesShowerInit.PFParticleLabel:                                  "pandoraPatRecInit:allOutcomes"
 


### PR DESCRIPTION
Looks like this was updated incorrectly when the initial files were merged together.

Fixing this now, and will do some further checks as well.

(For context, the DL config of Pandora uses the newer DL Vertexing etc....but it expects the cosmic free environment that NuGraph2 provides. Since `pandoraPatRecInit` runs before NuGraph2....the vertexing is running in an environment it was not trained in, and is likely latching on to cosmics and throwing off the vertexing. Since there is then NuGraph2 then the real, correctly configured Pandora, I expect the impact isn't as big as it could be, but there will certainly be some losses).