### PR TITLE
Feature/cthorpe eventfilter

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,4 +2,5 @@ cet_make_exec( track_hadd LIBRARIES ${ROOT_BASIC_LIB_LIST} )
 
 add_subdirectory(MiniBooNENtupletoGSimpleConversion)
 add_subdirectory(overlay_scripts)
+add_subdirectory(EventFilter)
 

--- a/tools/EventFilter/CMakeLists.txt
+++ b/tools/EventFilter/CMakeLists.txt
@@ -1,0 +1,2 @@
+install_scripts()
+install_fhicl()

--- a/tools/EventFilter/giveme_filtered_events.sh
+++ b/tools/EventFilter/giveme_filtered_events.sh
@@ -272,7 +272,7 @@ if [ $deletefiles -eq 1 ]; then
     rm $newsamdef*.list 
     rm *split*.txt
     rm run_EventFilter.fcl
-    #rm master_filelist.txt
+    rm master_filelist.txt
     rm $nmaxevents # have no idea why a file of this name gets made... but lets delete it!
 fi
 

--- a/tools/EventFilter/giveme_filtered_events.sh
+++ b/tools/EventFilter/giveme_filtered_events.sh
@@ -1,0 +1,286 @@
+#!/bin/sh
+# giveme_filtered_events.sh
+# Main Author: Marina Reggiani-Guzzo 
+# Tweaked by C Thorpe :) 
+
+# USAGE: giveme_filtered_events.sh <eventlist> <samdef> 
+# Make sure to update the input fields below
+
+# Description:
+# Purpose of the script is to convert a list of run subrun event list and filter
+# these events into one or many root files which you can easily use for scanning 
+# events in the event display. 
+
+# How it works:
+# The script takes the run subrun event list and if it is a large number of events,
+# then it splits it into n pieces where n is the number of events you specify by
+# the nmaxevents variable. It then runs a sam query to find the parent files that
+# are associated with those events. Be sure to configure the sam definition to be
+# the one where the run subrun event list will have come from and the type which 
+# tunes the sam query slightly. It then makes a sam defintion with all these files,
+# prestages these files so we can access them. Next a filelist with the full path to 
+# the files is created. We then run the event filter module which sives through all the
+# files and grabs out the events you are interesed in and puts them into a root file.
+# enjoy!
+
+# Useful note: Run this with nohup/screen/tmux since it prestages the files you give it
+
+# ---------------------------------------------------------------------------------
+
+# input: please check if variables correspond to your case
+
+# format: "run subrun event"
+runsubrunlist=$1
+
+# The name of the sam def which you made the run subrun event list from
+originalsamdef=$2
+
+# choose a name for your sam def, any name as long as it doesnt already exist
+newsamdef=$2_tmp
+
+# 0=data, 1=offbeam, 2=overlay
+#type=2
+
+# max number of events per new samdef created
+nmaxevents=200
+
+# keep the auxiliary files created during the process? 0=keep, 1=delete
+deletefiles=1
+
+# ---------------------------------------------------------------------------------
+
+
+
+
+
+
+
+# ---------------------------------------------------------------------------------
+BLUE="\033[1;34m"
+RED="\033[1;31m"
+YELLOW="\033[1;33m"
+DEFAULT="\033[0m"
+# ---------------------------------------------------------------------------------
+# because there is a limit of arguments to create a new samdef, it is necessary to 
+# split the runsubrunfile into smaller files
+# ---------------------------------------------------------------------------------
+
+echo -e "${BLUE}Splitting up run subrun event lists...${DEFAULT}"
+
+nlines=`wc -l < ${runsubrunlist}`
+if [ nlines > $nmaxevents ] ; then # split file
+
+    runsubrunlist_new="$(basename ${runsubrunlist} .txt)_split"
+
+    split -l $nmaxevents ${runsubrunlist} ${runsubrunlist_new} # split input file
+
+    for i in $runsubrunlist_new* ; do # loop to add extention to the splitted files
+    mv $i $i.txt
+    done
+
+    # List the split the file names in the current directory
+    ls $runsubrunlist_new*
+
+    runsubrunlist_arr=$( ls $runsubrunlist_new* ) # array of splitted files
+
+else
+
+    runsubrunlist_arr=$runsubrunlist
+
+fi
+
+echo 
+
+# --------------------------------------------------------------------------------- 
+# crete a file list by querying the input sam def
+# --------------------------------------------------------------------------------- 
+
+declare -a query_array=("and data_stream beam_good" "and data_stream all" "") # each type of data require a different query
+
+# Create a master filelist to catch any duplicate files
+touch master_filelist.txt
+
+echo -e "${BLUE}Creating the list of art-root files and checking for duplicate files from the sam query...${DEFAULT}"
+
+for f in ${runsubrunlist_arr[@]}; do
+
+    counter=0
+
+    for line in $(cat $f); do
+
+    if [ $counter -eq 0 ]; then
+            run=$line
+    elif [ $counter -eq 1  ]; then
+            subrun=$line
+            runsubrun="$run.$subrun"
+            
+            # Call sam and get the file. This can give multiple files e.g. beam good and bad files
+            #tempfiles=$(samweb list-files "defname:$originalsamdef and run_number $runsubrun ${query_array[${type}]}")
+            tempfiles=$(samweb list-files "defname:$originalsamdef and run_number $runsubrun")
+            
+            # Loop over the files 
+            for tempfile in $(echo "$tempfiles"); do
+                
+                # Add the file to the master list (this is for identifying duplicate files)
+                echo "$tempfile" >> master_filelist.txt
+		echo "$tempfile"
+
+                # Only add the file if it hasnt come up before
+                checkduplicate=$(cat master_filelist.txt | grep $tempfile)
+		echo $($check_duplicate)
+                if [ $(echo $check_duplicate | wc -l) -eq 1 ]; then
+                    echo "$tempfile" >> files_$(basename $f)
+                else 
+                    echo "Found a duplicate file (likely has multiple run subruns in the list specified) so not adding this to the list."
+                fi
+            
+            done
+           
+    fi
+
+    counter=$(($counter+1))
+    if [ $counter -eq 3 ]; then counter=0; fi
+
+    done
+
+done
+    
+fileslist_arr=$( ls files_* ) # array with the name of the files that contain the artroot file name of the selected events
+
+echo
+
+# ---------------------------------------------------------------------------------
+# create a samdef from the files and prestage the files
+# ---------------------------------------------------------------------------------
+
+declare -a newsamdef_arr=()
+counter=0
+
+for i in ${fileslist_arr[@]}; do
+
+    newsamdeftemp=${newsamdef}_${counter}
+    newsamdef_arr+=( $newsamdeftemp )
+
+    files=`awk '{print $newsamdef}' $i | paste -s -d, -`
+    files=$files
+
+    samweb create-definition $newsamdeftemp "file_name $files"
+
+    echo
+    echo -e "${BLUE}samweb prestage-dataset --defname="$newsamdeftemp" --parallel=4${DEFAULT}";
+    samweb prestage-dataset --defname="$newsamdeftemp" --parallel=4
+    echo 
+    echo "Prestage complete!"
+    echo
+
+    counter=$(($counter+1))
+    
+done
+
+# ---------------------------------------------------------------------------------
+# create a filelist with the full path
+# ---------------------------------------------------------------------------------
+
+declare -a filelist_fullpath=()
+counter=0
+
+echo 
+echo -e "${BLUE}Creating the filelists with full paths...${DEFAULT}"
+
+for def in ${newsamdef_arr[@]}; do
+
+    for files in `samweb list-files defname: $def`; do
+
+    # locate the file
+    newfile=`samweb locate-file "${files}"`
+
+    # get rid of enstore in the name
+    modnewfile=${newfile#"enstore:"}
+
+    # get rid of anything after the bracket
+    modnewfile=${modnewfile%(*}
+    
+    # create the full path
+    modnewfile="${modnewfile}/${files}"
+    echo $modnewfile
+
+        # Put into the new file                                                     
+    echo ${modnewfile} >> ${def}_file.list
+
+    done
+
+    echo
+    echo -e "${BLUE}${def}_file.list CREATED${DEFAULT}"
+
+    filelist_fullpath+=( ${def}_file.list )
+
+done
+
+# ---------------------------------------------------------------------------------
+# running fhicl file
+# ---------------------------------------------------------------------------------
+
+counter=0
+
+# copy the event fcl file over (hopefully this fcl wont ever get deleted)
+#cp /exp/uboone/app/users/cthorpe/throwaway/test/run_EventFilter.fcl  .
+fhicl_loc=$(find_fhicl.sh run_EventFilter.fcl | tail -n 1)
+cp $fhicl_loc . 
+
+echo
+echo
+echo -e "${BLUE}Running the Event Filter...${DEFAULT}"
+
+for s in ${runsubrunlist_arr[@]}; do
+
+    # first delete the following lines
+    sed -i '/^physics.filters.filter.EventList/d' run_EventFilter.fcl
+    sed -i '/^physics.filters.filter.Selection/d' run_EventFilter.fcl
+
+    # adding those lines again with new file
+    echo "physics.filters.filter.EventList: \"${s}\"" >> run_EventFilter.fcl
+    echo "physics.filters.filter.Selection: 1" >> run_EventFilter.fcl
+    
+    echo -e "${RED}lar -c run_EventFilter.fcl -S ${filelist_fullpath[$counter]} -o filtered_${newsamdef_arr[$counter]}.root${DEFAULT}"
+    eval "lar -c run_EventFilter.fcl -S ${filelist_fullpath[$counter]} -o filtered_${newsamdef_arr[$counter]}.root"
+    echo
+
+    counter=$(($counter+1))
+
+done
+
+
+# ---------------------------------------------------------------------------------
+# print a summary of the events you have just filtered
+# ---------------------------------------------------------------------------------
+
+echo -e "${YELLOW}-------------SUMMARY"
+echo "samdef:                          ${originalsamdef}"
+echo "number of events:                ${nlines}"
+echo "new samdef:                      ${newsamdef_arr[@]}"
+echo -e "--------------------${DEFAULT}"
+
+# ---------------------------------------------------------------------------------
+# delete auxiliary files?
+# ---------------------------------------------------------------------------------
+
+# echo ${#runsubrunlist_arr[@]}
+
+if [ $deletefiles -eq 1 ]; then
+    echo
+    echo "Removing file lists..."
+    rm $newsamdef*.list 
+    rm *split*.txt
+    rm run_EventFilter.fcl
+    #rm master_filelist.txt
+    rm $nmaxevents # have no idea why a file of this name gets made... but lets delete it!
+fi
+
+# Cleanup the sam definitions made
+for def in ${newsamdef_arr[@]}; do
+    echo "samweb delete-definition $def"
+    samweb delete-definition $def
+done
+
+echo 
+echo "FINSHED!"

--- a/tools/EventFilter/run_EventFilter.fcl
+++ b/tools/EventFilter/run_EventFilter.fcl
@@ -1,0 +1,56 @@
+#include "filters.fcl"
+process_name: Filter1
+services:
+{
+  TimeTracker:       {}
+  RandomNumberGenerator: {} #ART native random number generator
+}
+
+#source is now a root file
+source:
+{
+  module_type: RootInput
+  #maxEvents:  10        # Number of events to create
+  #inputCommands: [ "keep *", "drop sumdata::RunData_*_*_*" ]
+}
+outputs:
+{
+ out1:
+ {
+   module_type: RootOutput
+   fileName:    "nuexsec_data_filtered.root" #default file name, can override from command line with -o or --output
+   SelectEvents:[reco]
+   fastCloning: true
+   dataTier: "reconstructed"
+ }
+}
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+ filters:
+ {
+  filter:  @local::evtfilter
+ }
+ 
+#define the producer and filter modules for this path, order matters, 
+ #filters reject all following items.  see lines starting physics.producers below
+ reco: [ filter ] 
+
+ # define the output stream, there could be more than one if using filters 
+ stream1:  [ out1 ]
+ 
+ #trigger_paths is a keyword and contains the paths that modify the art::event, 
+ #ie filters and producers
+ trigger_paths: [ reco ] 
+ 
+ #end_paths is a keyword and contains the paths that do not modify the art::Event, 
+ #ie analyzers and output streams.  these all run simultaneously
+ end_paths:     [ stream1 ]  
+}
+
+physics.filters.filter.EventList: "run1_run_subrun_list_data.txt"
+physics.filters.filter.EventList: "test.list"
+physics.filters.filter.Selection: 1
+


### PR DESCRIPTION
Adding the giveme_filtered_events.sh script commonly used by analysers to select small numbers of events from sam definitions. Also added run_EventFilter.fcl, the fhicl used to run the filtering. 

Small tweaks made to giveme_filtered_events.sh to enable arguments to be passed to it on the commandline, along with CMakeLists to ensure it's installed and in the system path when larsoft/uboonecode are set up.