### PR TITLE
Trash stash cache

### DIFF
--- a/test/CRTSwizzle/crt_swizzle.sh
+++ b/test/CRTSwizzle/crt_swizzle.sh
@@ -6,7 +6,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/DataProduction/data_production.sh
+++ b/test/DataProduction/data_production.sh
@@ -6,7 +6,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/DataProductionMCC9/data_production_mcc9.sh
+++ b/test/DataProductionMCC9/data_production_mcc9.sh
@@ -17,7 +17,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/DataWCUnifiedMCC9/data_wc_unified_mcc9.sh
+++ b/test/DataWCUnifiedMCC9/data_wc_unified_mcc9.sh
@@ -6,7 +6,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/GENIE/genie.sh
+++ b/test/GENIE/genie.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# Exit if pnfs persistent isn't mounted.
+
+if [ ! -d /pnfs/uboone/persistent ]; then
+  exit
+fi
+
 # Set up python path.
 
 export PYTHONPATH=`pwd`:$UBUTIL_DIR/python:$LARBATCH_DIR/python:$PYTHONPATH

--- a/test/GENIE/test_genie_simple.fcl
+++ b/test/GENIE/test_genie_simple.fcl
@@ -66,5 +66,5 @@ physics.producers.generator.TopVolume:          "volCryostat"
 physics.producers.generator.BeamName:           "booster"
 physics.producers.generator.FluxType:           "simple_flux"
 physics.producers.generator.FluxFiles:          [ "converted_beammc_wincorr*.root" ]
-physics.producers.generator.FluxSearchPaths:    "/cvmfs/uboone.osgstorage.org/stash/uboonebeam/bnb_gsimple/bnb_gsimple_fluxes_01.09.2019_463/"
+physics.producers.generator.FluxSearchPaths:    "/pnfs/uboone/persistent/stash/uboonebeam/bnb_gsimple/bnb_gsimple_fluxes_01.09.2019_463/"
 physics.producers.generator.FluxCopyMethod:     "DIRECT"

--- a/test/OverlayOpticalProductionMCC9/overlay_optical_production_mcc9.sh
+++ b/test/OverlayOpticalProductionMCC9/overlay_optical_production_mcc9.sh
@@ -6,7 +6,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/OverlayProduction/overlay_production.sh
+++ b/test/OverlayProduction/overlay_production.sh
@@ -6,7 +6,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/OverlayProductionMCC9/overlay_production_mcc9.sh
+++ b/test/OverlayProductionMCC9/overlay_production_mcc9.sh
@@ -17,7 +17,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/OverlayWCUnifiedMCC9/overlay_wc_unified_mcc9.sh
+++ b/test/OverlayWCUnifiedMCC9/overlay_wc_unified_mcc9.sh
@@ -6,7 +6,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/PPFX/ppfx.sh
+++ b/test/PPFX/ppfx.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# Exit if pnfs persistent isn't mounted.
+
+if [ ! -d /pnfs/uboone/persistent ]; then
+  exit
+fi
+
 # Make sure we can find ppfx config file in mrbsetenv environment, since the install
 # subdirectory is different than the source subdirectory.
 

--- a/test/PPFX/test_genie_dk2nu.fcl
+++ b/test/PPFX/test_genie_dk2nu.fcl
@@ -69,6 +69,6 @@ physics.producers.generator.BeamName:           "numi"
 physics.producers.generator.EventGeneratorList: "Default"
 physics.producers.generator.FluxType:           "dk2nu"
 physics.producers.generator.FluxFiles:          [ "g4numiv6_*.root" ]
-physics.producers.generator.FluxSearchPaths:    "/cvmfs/uboone.osgstorage.org/stash/uboonebeam/numi_dk2nu_zero_threshold/FHC/"
+physics.producers.generator.FluxSearchPaths:    "/pnfs/uboone/persistent/stash/uboonebeam/numi_dk2nu_zero_threshold/FHC/"
 physics.producers.generator.DetectorLocation:   "microboone-numi-v2"
 physics.producers.generator.FluxCopyMethod:     "DIRECT"

--- a/test/SQLiteTestReco1MCC9/sqlite_test_reco1_mcc9.sh
+++ b/test/SQLiteTestReco1MCC9/sqlite_test_reco1_mcc9.sh
@@ -17,7 +17,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/SQLiteTestReco2MCC9/sqlite_test_reco2_mcc9.sh
+++ b/test/SQLiteTestReco2MCC9/sqlite_test_reco2_mcc9.sh
@@ -17,7 +17,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/SQLiteTestReco2MCC9_run3/sqlite_test_reco2_mcc9_run3.sh
+++ b/test/SQLiteTestReco2MCC9_run3/sqlite_test_reco2_mcc9_run3.sh
@@ -17,7 +17,7 @@ env > env.txt
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit

--- a/test/Swizzle/swizzle.sh
+++ b/test/Swizzle/swizzle.sh
@@ -25,7 +25,7 @@ export SSL_CERT_DIR=/cvmfs/oasis.opensciencegrid.org/mis/certificates
 
 # Exit if stash cache isn't mounted.
 
-UBOONE_EXAMPLE_DATA_DIR=/cvmfs/uboone.osgstorage.org/stash/uboone_example_data
+UBOONE_EXAMPLE_DATA_DIR=/pnfs/uboone/persistent/stash/uboone_example_data
 if [ ! -d $UBOONE_EXAMPLE_DATA_DIR ]; then
   echo "Quittig because stash cache isn't available."
   exit


### PR DESCRIPTION
Update integration tests to read example data and fluxes from /pnfs/uboone/persistent instead of stash cache.