### PR TITLE
Setting NuRandomService policy to 'perEvent'

### DIFF
--- a/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_stage2.fcl
+++ b/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_stage2.fcl
@@ -10,6 +10,8 @@ services.DetectorClocksService.InheritClockConfig:  false
 services.TFileService.fileName: "reco_stage_2_hist.root"
 services.DetectorClocksService.InheritClockConfig:  false
 
+services.NuRandomService.policy: "perEvent"
+
 physics.producers.trajcluster.TrajClusterAlg.MatchTruth: [ -1, -1, -1, -1 ]
 physics.producers.trajcluster.DoRawDigitAssns: false
 


### PR DESCRIPTION
Changing uboonecode/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_stage2.fcl to override NuRandomService policy to "perEvent"