### PR TITLE
Prevent crt merging scripts from dropping

### DIFF
--- a/fcl/crt/crt_merge_extra_v06_26_01_13.fcl
+++ b/fcl/crt/crt_merge_extra_v06_26_01_13.fcl
@@ -94,6 +94,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_13
 
 physics.producers.merger.debug: false

--- a/fcl/crt/crt_merge_extra_v06_26_01_13_33.fcl
+++ b/fcl/crt/crt_merge_extra_v06_26_01_13_33.fcl
@@ -94,6 +94,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_13
 services.CRTFileManager.ubversion_CRTHits_top: prod_v06_26_01_33
 

--- a/fcl/crt/crt_merge_extra_v06_26_01_26.fcl
+++ b/fcl/crt/crt_merge_extra_v06_26_01_26.fcl
@@ -94,6 +94,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_26
 
 physics.producers.merger.debug: false

--- a/fcl/crt/crt_merge_extra_v06_26_01_33.fcl
+++ b/fcl/crt/crt_merge_extra_v06_26_01_33.fcl
@@ -94,6 +94,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_33
 
 physics.producers.merger.debug: false

--- a/fcl/crt/crt_merge_v06_26_01_13.fcl
+++ b/fcl/crt/crt_merge_v06_26_01_13.fcl
@@ -92,6 +92,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_13
 
 physics.producers.merger.debug: false

--- a/fcl/crt/crt_merge_v06_26_01_13_33.fcl
+++ b/fcl/crt/crt_merge_v06_26_01_13_33.fcl
@@ -92,6 +92,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_13
 services.CRTFileManager.ubversion_CRTHits_top: prod_v06_26_01_33
 

--- a/fcl/crt/crt_merge_v06_26_01_26.fcl
+++ b/fcl/crt/crt_merge_v06_26_01_26.fcl
@@ -92,6 +92,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_26
 
 physics.producers.merger.debug: false

--- a/fcl/crt/crt_merge_v06_26_01_33.fcl
+++ b/fcl/crt/crt_merge_v06_26_01_33.fcl
@@ -92,6 +92,8 @@ services.message.destinations:
   }
 }
 
+source.dropDescendantsOfDroppedBranches: false
+
 services.CRTFileManager.ubversion_CRTHits: prod_v06_26_01_33
 
 physics.producers.merger.debug: false


### PR DESCRIPTION
Add fhicl parameter to prevent the crt merging fhicls from dropping descendent branches. This is needed for the retupling workflows.