### PR TITLE
Run123 detvar fhicls

### DIFF
--- a/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_numi_wiremod_stage2b_sce.fcl
+++ b/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_numi_wiremod_stage2b_sce.fcl
@@ -1,0 +1,2 @@
+#include "reco_uboone_mcc9_10_driver_overlay_numi_stage2b_sce.fcl"
+physics.producers.blipreco.BlipAlg.HitTruthMatch: "gaushitTruthMatch::OverlayWireModRecoStage1b"

--- a/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_wiremod_stage2b_sce.fcl
+++ b/fcl/reco/MCC10/reco_uboone_mcc9_10_driver_overlay_wiremod_stage2b_sce.fcl
@@ -1,0 +1,2 @@
+#include "reco_uboone_mcc9_10_driver_overlay_stage2b_sce.fcl"
+physics.producers.blipreco.BlipAlg.HitTruthMatch: "gaushitTruthMatch::OverlayWireModRecoStage1b"


### PR DESCRIPTION
Two new fhicls which are need for running WireMod samples in runs1-3 where the special SCE treatment is needed.